### PR TITLE
Pass result element type to XlaBuilder for `mhlo.dot_general` and `mh…

### DIFF
--- a/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Dialect/mhlo/IR/hlo_ops.td
+++ b/tensorflow/compiler/mlir/hlo/include/mlir-hlo/Dialect/mhlo/IR/hlo_ops.td
@@ -960,6 +960,9 @@ def HLO_DotGeneralOp: HLO_Op<"dot_general", [NoSideEffect]>,
 
   let results = (outs HLO_Tensor);
   let verifier = [{ return Verify(*this); }];
+  // DotGeneral op required custom exporter to pass the preferred element type
+  // to Xla builder.
+  let hasCustomHLOConverter = 1;
 }
 
 // Define Base Einsum op within the HLO dialect as these are client ops and


### PR DESCRIPTION
…lo.convolution` ops.

`mhlo.dot_general` and `mhlo.convolution` result element type might be different from operand element type. See `preferred_element_type` attribute that allows i8xi8 to i32 dot computation. `mhlo` to HLO exporter should pass the result element type to Xla builder to override the shape inference of XLA.

PiperOrigin-RevId: 358580718
Change-Id: If3ad34b6824a52498663f0a1a031a5bdc29a24ee